### PR TITLE
Minor ticks before first major tick

### DIFF
--- a/src/entities/axis.cpp
+++ b/src/entities/axis.cpp
@@ -101,7 +101,6 @@ std::pair<double, double> AxisEntity::calculateTickStartAndDelta() const
             break;
 
     } while ((nTicks > maxTicks) || (nTicks < minTicks));
-
     return {tickStart, tickDelta};
 }
 
@@ -119,8 +118,19 @@ std::vector<std::pair<double, bool>> AxisEntity::generateLinearTicks(double tick
 
     auto count = 0;
     auto delta = tickDelta / (nSubTicks_ + 1);
-    auto value = tickStart;
+    auto value = tickStart - delta;
     std::vector<std::pair<double, bool>> ticks;
+
+    // Go backwards from the first major tick, filling in minor ticks.
+    while (value >= minimum_)
+    {
+        auto x = toGlobal(value);
+        ticks.emplace_back(value, false);
+        value -= delta;
+    }
+
+    value = tickStart;
+
     while (value <= maximum_)
     {
         // Add tick here, only if value >= minimum_


### PR DESCRIPTION
A small PR which updates `AxisEntity::generateLinearTicks` to add minor ticks before the first major tick. This solves the problem of minor ticks not appearing when translating the graph so that a major tick is not at the origin. This only relates to when linear ticks are being used (i.e. not when logarithmic axes are in use). Closes #12.