### PR TITLE
Phong Fix

### DIFF
--- a/src/shaders/clipped.vert
+++ b/src/shaders/clipped.vert
@@ -8,10 +8,11 @@ in vec4 vertexColor;
 // Output Vertex Data
 out worldData
 {
-  vec3 position;
-  vec3 normal;
-  vec4 color;
-} world;
+    vec3 position;
+    vec3 normal;
+    vec4 color;
+}
+world;
 
 // Standard uniform variables per-primitive
 uniform mat4 modelMatrix;
@@ -26,29 +27,29 @@ uniform vec3 sceneDataAxesOrigin;
 
 void main()
 {
-  // Convert vertex position to a vec4
-  vec4 vertexPosition4 = vec4(vertexPosition, 1.0);
+    // Convert vertex position to a vec4
+    vec4 vertexPosition4 = vec4(vertexPosition, 1.0);
 
-  // Transform vertex data to world space
-  world.position = vec3(modelMatrix * vertexPosition4);
-  world.normal = modelNormalMatrix * vertexNormal;
-  world.color = vertexColor;
+    // Transform vertex data to world space
+    world.position = vec3(modelMatrix * vertexPosition4);
+    world.normal = modelNormalMatrix * vertexNormal;
+    world.color = vertexColor;
 
-  // Transform vertex into "plain" data space
-  vec4 dataPosition = sceneDataTransformInverse * vec4(world.position, 1.0);
-  dataPosition.xyz -= sceneDataAxesOrigin;
+    // Transform vertex into "plain" data space
+    vec4 dataPosition = sceneDataTransformInverse * vec4(world.position, 1.0);
+    dataPosition.xyz -= sceneDataAxesOrigin;
 
-  // Clip vertices to data volume
-  // -- X axis
-  gl_ClipDistance[0] = dot(dataPosition, sceneDataAxes[0].xyzw);
-  gl_ClipDistance[1] = dot(dataPosition, vec4(-sceneDataAxes[0].xyz, sceneDataAxesExtents.x));
-  // -- Y axis
-  gl_ClipDistance[2] = dot(dataPosition, sceneDataAxes[1].xyzw);
-  gl_ClipDistance[3] = dot(dataPosition, vec4(-sceneDataAxes[1].xyz, sceneDataAxesExtents.y));
-  // -- Z axis
-  gl_ClipDistance[4] = dot(dataPosition, sceneDataAxes[2].xyzw);
-  gl_ClipDistance[5] = dot(dataPosition, vec4(-sceneDataAxes[2].xyz, sceneDataAxesExtents.z));
+    // Clip vertices to data volume
+    // -- X axis
+    gl_ClipDistance[0] = dot(dataPosition, sceneDataAxes[0].xyzw);
+    gl_ClipDistance[1] = dot(dataPosition, vec4(-sceneDataAxes[0].xyz, sceneDataAxesExtents.x));
+    // -- Y axis
+    gl_ClipDistance[2] = dot(dataPosition, sceneDataAxes[1].xyzw);
+    gl_ClipDistance[3] = dot(dataPosition, vec4(-sceneDataAxes[1].xyz, sceneDataAxesExtents.y));
+    // -- Z axis
+    gl_ClipDistance[4] = dot(dataPosition, sceneDataAxes[2].xyzw);
+    gl_ClipDistance[5] = dot(dataPosition, vec4(-sceneDataAxes[2].xyz, sceneDataAxesExtents.z));
 
-  // Output projected vertex position
-  gl_Position = modelViewProjection * vertexPosition4;
+    // Output projected vertex position
+    gl_Position = modelViewProjection * vertexPosition4;
 }

--- a/src/shaders/line_tesselator.geom
+++ b/src/shaders/line_tesselator.geom
@@ -1,7 +1,7 @@
 #version 330
 
-layout (lines) in;
-layout (triangle_strip, max_vertices = 4) out;
+layout(lines) in;
+layout(triangle_strip, max_vertices = 4) out;
 
 // Input Vertex Data
 in worldData
@@ -9,14 +9,17 @@ in worldData
     vec3 position;
     vec3 normal;
     vec4 color;
-} vertices[];
+}
+vertices[];
 
 // Output Fragment Data
 out fragData
 {
+    vec3 position;
     vec3 normal;
     vec4 color;
-} frag;
+}
+frag;
 
 uniform vec2 viewportSize;
 uniform float lineWidth = 1.5;
@@ -37,27 +40,31 @@ void main()
     vec4 p1 = gl_in[0].gl_Position;
     vec4 p2 = gl_in[1].gl_Position;
 
-    vec2 dir    = normalize((p2.xy - p1.xy) * viewportSize);
+    vec2 dir = normalize((p2.xy - p1.xy) * viewportSize);
     vec2 offset = vec2(-dir.y, dir.x) * lineWidth / viewportSize;
 
     // Emit the four corners of our two triangles
     gl_Position = p1 + vec4(offset.xy * p1.w, 0.0, 0.0);
     applyClipping(0);
+    frag.position = vec3(gl_Position);
     frag.color = vertices[0].color;
     frag.normal = vertices[1].normal;
     EmitVertex();
     gl_Position = p1 - vec4(offset.xy * p1.w, 0.0, 0.0);
     applyClipping(0);
+    frag.position = vec3(gl_Position);
     frag.color = vertices[0].color;
     frag.normal = vertices[0].normal;
     EmitVertex();
     gl_Position = p2 + vec4(offset.xy * p2.w, 0.0, 0.0);
     applyClipping(1);
+    frag.position = vec3(gl_Position);
     frag.color = vertices[1].color;
     frag.normal = vertices[1].normal;
     EmitVertex();
     gl_Position = p2 - vec4(offset.xy * p2.w, 0.0, 0.0);
     applyClipping(1);
+    frag.position = vec3(gl_Position);
     frag.color = vertices[1].color;
     frag.normal = vertices[1].normal;
     EmitVertex();

--- a/src/shaders/phong.frag
+++ b/src/shaders/phong.frag
@@ -1,8 +1,13 @@
 #version 150 core
 
 // Input variables
-in vec3 worldNormal;
-in vec3 worldPosition;
+in fragData
+{
+    vec3 position;
+    vec3 normal;
+    vec4 color;
+}
+frag;
 
 // Uniform variables per-primitive
 // -- Colour components
@@ -21,27 +26,26 @@ uniform vec3 lightPosition;
 // Output variables
 out vec4 fragColour;
 
-void main() {
-  // Calculate normalised surface normal and light vector
-  vec3 N = normalize(worldNormal);
-  vec3 L = normalize(lightPosition - worldPosition);
+void main()
+{
+    // Calculate normalised surface normal and light vector
+    vec3 N = normalize(frag.normal);
+    vec3 L = normalize(lightPosition - frag.position);
 
-  // Lambert's cosine law
-  float lambertian = max(dot(N, L), 0.0);
-  float specPow = 0.0;
-  if (lambertian > 0.0)
-  {
-    // Calculate reflected light vector and vector to viewer
-    vec3 R = reflect(-L, N);
-    vec3 V = normalize(-worldPosition);
+    // Lambert's cosine law
+    float lambertian = max(dot(N, L), 0.0);
+    float specPow = 0.0;
+    if (lambertian > 0.0)
+    {
+        // Calculate reflected light vector and vector to viewer
+        vec3 R = reflect(-L, N);
+        vec3 V = normalize(-frag.position);
 
-    // Compute the specular term
-    float specAngle = max(dot(R, V), 0.0);
-    specPow = pow(specAngle, shininess*128);
-  }
+        // Compute the specular term
+        float specAngle = max(dot(R, V), 0.0);
+        specPow = pow(specAngle, shininess * 128);
+    }
 
-  // Construct final colour
-  fragColour = vec4(ka * ambient +
-                      kd * lambertian * diffuse +
-                      ks * specPow * specular, 1.0);
+    // Construct final colour
+    fragColour = vec4(ka * vec3(ambient) + kd * lambertian * diffuse + ks * specPow * specular, 1.0);
 }

--- a/src/shaders/phongpervertex.frag
+++ b/src/shaders/phongpervertex.frag
@@ -8,6 +8,7 @@ in vec4 worldColor;
 // Input Fragment Data
 in fragData
 {
+  vec3 position;
   vec3 normal;
   vec4 color;
 } frag;
@@ -31,8 +32,8 @@ out vec4 fragColour;
 
 void main() {
   // Calculate normalised surface normal and light vector
-  vec3 N = normalize(worldNormal);
-  vec3 L = normalize(lightPosition - worldPosition);
+  vec3 N = normalize(frag.normal);
+  vec3 L = normalize(lightPosition - frag.position);
 
   // Lambert's cosine law
   float lambertian = max(dot(N, L), 0.0);
@@ -41,7 +42,7 @@ void main() {
   {
     // Calculate reflected light vector and vector to viewer
     vec3 R = reflect(-L, N);
-    vec3 V = normalize(-worldPosition);
+    vec3 V = normalize(-frag.position);
 
     // Compute the specular term
     float specAngle = max(dot(R, V), 0.0);


### PR DESCRIPTION
This PR addresses issues with the Phong shaders - specifically, on IDAaaS VMs significant flickering and incorrect colouring of displayed data sets was evident, while on other tested systems this did not occur and data displayed correctly.

The underlying cause was down to the use of several shader input variables which were never actually set. The assumption is that, on some systems, they are not pre-initialised to sensible defaults (why should they be!) and so corruption of the rendering occurred.