### PR TITLE
Add squares

### DIFF
--- a/examples/errors/mainwindow.h
+++ b/examples/errors/mainwindow.h
@@ -37,6 +37,7 @@ class MainWindow : public QMainWindow
     // Style
     Mildred::StyleFactory1D::ErrorBarStyle style_{Mildred::StyleFactory1D::ErrorBarStyle::Stick};
     Mildred::StyleFactory1D::SymbolStyle shapeStyle_{Mildred::StyleFactory1D::SymbolStyle::Triangle};
+
     /*
      * Data
      */

--- a/examples/errors/mainwindow_funcs.cpp
+++ b/examples/errors/mainwindow_funcs.cpp
@@ -38,10 +38,13 @@ MainWindow::MainWindow() : QMainWindow()
     dataEntity_ = ui_.TestingWidget->addData1D("Sin");
     dataEntity_->setData(xValues_, yValues_, uniformErrors_);
     dataEntity_->setSymbolStyle(Mildred::StyleFactory1D::SymbolStyle::Triangle);
+    dataEntity_->setSymbolStyle(Mildred::StyleFactory1D::SymbolStyle::Square);
 
     ui_.StyleCombo->addItem(QString("Stick"));
     ui_.StyleCombo->addItem(QString("T-Bar Stick"));
     ui_.SymbolCombo->addItem(QString("Triangle"));
+    ui_.SymbolCombo->addItem(QString("Square"));
+    ui_.SymbolCombo->addItem(QString("None"));
     ui_.WidthSpin->setValue(10.0);
     ui_.SymbolSizeSpin->setValue(12.0);
 
@@ -89,7 +92,8 @@ void MainWindow::on_ShowSymbolsCheck_selected(bool checked)
 
 void MainWindow::on_SymbolStyleCombo_currentShapeIndexChanged(int shapeindex)
 {
-    shapeStyle_ = shapeindex == 0 ? Mildred::StyleFactory1D::SymbolStyle::Triangle : Mildred::StyleFactory1D::SymbolStyle::None;
+    shapeStyle_ =
+        shapeindex == 0 ? Mildred::StyleFactory1D::SymbolStyle::Triangle : Mildred::StyleFactory1D::SymbolStyle::Square;
     if (ui_.ShowSymbolsCheck->isChecked())
     {
         dataEntity_->setSymbolStyle(shapeStyle_);

--- a/src/renderers/1d/CMakeLists.txt
+++ b/src/renderers/1d/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
   stylefactory.cpp
   symbol_base.cpp
   symbol_triangle.cpp
+  symbol_square.cpp
   base.h
   line.h
   none.h
@@ -15,7 +16,8 @@ add_library(
   error_none.h
   stylefactory.h
   symbol_none.h
-  symbol_triangle.h)
+  symbol_triangle.h
+  symbol_square.h)
 
 target_include_directories(
   renderers1d

--- a/src/renderers/1d/stylefactory.cpp
+++ b/src/renderers/1d/stylefactory.cpp
@@ -5,6 +5,7 @@
 #include "renderers/1d/line.h"
 #include "renderers/1d/none.h"
 #include "renderers/1d/symbol_none.h"
+#include "renderers/1d/symbol_square.h"
 #include "renderers/1d/symbol_triangle.h"
 #include <stdexcept>
 
@@ -39,6 +40,8 @@ std::shared_ptr<SymbolRenderer1D> createSymbolRenderer(SymbolStyle style, Qt3DCo
         return std::make_shared<NoSymbolRenderer1D>(rootEntity);
     if (style == SymbolStyle::Triangle)
         return std::make_shared<TriangleSymbolRenderer1D>(rootEntity);
+    if (style == SymbolStyle::Square)
+        return std::make_shared<SquareSymbolRenderer1D>(rootEntity);
 
     throw(std::runtime_error("DataRenderer1D::createSymbolRenderer() - Style not accounted for.\n"));
 }

--- a/src/renderers/1d/symbol_square.cpp
+++ b/src/renderers/1d/symbol_square.cpp
@@ -48,18 +48,14 @@ void SquareSymbolRenderer1D::create(const ColourDefinition &colour, const std::v
         symbols_->addIndex(i++);
         symbols_->addVertex(centre + QVector3D(-w, -w, 0.0), colour_.colour(*vit));
         symbols_->addIndex(i++);
-        symbols_->addVertex(centre + QVector3D(0.0, -w, 0.0), colour_.colour(*vit));
-        symbols_->addIndex(i++);
 
         symbols_->addVertex(centre + QVector3D(w, -w, 0.0), colour_.colour(*vit));
         symbols_->addIndex(i++);
         symbols_->addVertex(centre + QVector3D(w, w, 0.0), colour_.colour(*vit));
         symbols_->addIndex(i++);
-        symbols_->addVertex(centre + QVector3D(0.0, w, 0.0), colour_.colour(*vit));
-        symbols_->addIndex(i++);
 
         // Close the square!
-        symbols_->addIndex(i - 6);
+        symbols_->addIndex(i - 4);
 
         // Add restart index, to cause line break.
         symbols_->addIndex(-1);

--- a/src/renderers/1d/symbol_square.cpp
+++ b/src/renderers/1d/symbol_square.cpp
@@ -1,0 +1,72 @@
+#include "renderers/1d/symbol_square.h"
+
+using namespace Mildred;
+
+SquareSymbolRenderer1D::SquareSymbolRenderer1D(Qt3DCore::QEntity *rootEntity) : SymbolRenderer1D(rootEntity)
+{
+    symbols_ = new LineEntity(rootEntity_);
+}
+
+SquareSymbolRenderer1D::~SquareSymbolRenderer1D()
+{
+    if (symbols_)
+        symbols_->setParent(static_cast<Qt3DCore::QNode *>(nullptr));
+};
+
+/*
+ * Rendering
+ */
+
+// Create entities from the supplied metrics and data
+void SquareSymbolRenderer1D::create(const ColourDefinition &colour, const std::vector<double> &x, const AxisEntity *xAxis,
+                                    const std::vector<double> &values, const AxisEntity *valueAxis)
+{
+    assert(symbols_);
+    symbols_->clear();
+
+    colour_ = colour;
+
+    // Check array sizes
+    if (x.size() != values.size())
+    {
+        printf("Irregular vector sizes provided (%zu (x) vs %zu (y)) so can't create entities.\n", x.size(), values.size());
+        symbols_->finalise();
+        return;
+    }
+
+    // Loop over data and add vertices
+    auto xit = x.cbegin(), vit = values.cbegin();
+    auto i = 0;
+    auto w = symbolMetric_ / 2.0;
+    while (xit != x.end())
+    {
+        // Get datapoint value in scaled coordinates
+        auto centre = xAxis->toScaled(*xit) + valueAxis->toScaled(*vit);
+
+        // Square Vertices
+        symbols_->addVertex(centre + QVector3D(-w, w, 0.0), colour_.colour(*vit));
+        symbols_->addIndex(i++);
+        symbols_->addVertex(centre + QVector3D(-w, -w, 0.0), colour_.colour(*vit));
+        symbols_->addIndex(i++);
+        symbols_->addVertex(centre + QVector3D(0.0, -w, 0.0), colour_.colour(*vit));
+        symbols_->addIndex(i++);
+
+        symbols_->addVertex(centre + QVector3D(w, -w, 0.0), colour_.colour(*vit));
+        symbols_->addIndex(i++);
+        symbols_->addVertex(centre + QVector3D(w, w, 0.0), colour_.colour(*vit));
+        symbols_->addIndex(i++);
+        symbols_->addVertex(centre + QVector3D(0.0, w, 0.0), colour_.colour(*vit));
+        symbols_->addIndex(i++);
+
+        // Close the square!
+        symbols_->addIndex(i - 6);
+
+        // Add restart index, to cause line break.
+        symbols_->addIndex(-1);
+        ++xit;
+        ++vit;
+    }
+
+    // Finalise the entity
+    symbols_->finalise();
+}

--- a/src/renderers/1d/symbol_square.h
+++ b/src/renderers/1d/symbol_square.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "entities/line.h"
+#include "renderers/1d/base.h"
+
+namespace Mildred
+{
+//! SquareSymbolRenderer1D renders 1D data symbols as a square.
+/*!
+ * SquareSymbolRenderer1D manages the creation of entities for displaying 1D data as a simple square.
+ */
+class SquareSymbolRenderer1D : public SymbolRenderer1D
+{
+    public:
+    SquareSymbolRenderer1D(Qt3DCore::QEntity *rootEntity);
+    ~SquareSymbolRenderer1D();
+
+    /*
+     * Rendering
+     */
+    private:
+    // Line entity
+    LineEntity *symbols_{nullptr};
+
+    public:
+    // Create entities from the supplied metrics and data
+    void create(const ColourDefinition &colour, const std::vector<double> &x, const AxisEntity *xAxis,
+                const std::vector<double> &values, const AxisEntity *valueAxis) override;
+};
+
+} // namespace Mildred


### PR DESCRIPTION
- This Pull-Request adds Square Data markers to the "Errors" Example output binary.
- Users may now choose between Data markers in the form of Triangles or Squares, or simply choose not to display them.