### PR TITLE
Line Stipple Shader

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -71,6 +71,10 @@ RenderableMaterial::RenderableMaterial(Qt3DCore::QNode *parent, VertexShaderType
             shader3->setFragmentShaderCode(
                 Qt3DRender::QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/shaders/shaders/monochrome.frag"))));
             break;
+        case (FragmentShaderType::LineStipple):
+            shader3->setFragmentShaderCode(
+                Qt3DRender::QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/shaders/shaders/line_stipple.frag"))));
+            break;
         case (FragmentShaderType::Phong):
             shader3->setFragmentShaderCode(
                 Qt3DRender::QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/shaders/shaders/phong.frag"))));

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -62,6 +62,10 @@ RenderableMaterial::RenderableMaterial(Qt3DCore::QNode *parent, VertexShaderType
             shader3->setGeometryShaderCode(
                 Qt3DRender::QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/shaders/shaders/line_tesselator.geom"))));
             break;
+        case (GeometryShaderType::LineStipple):
+            shader3->setGeometryShaderCode(
+                Qt3DRender::QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/shaders/shaders/line_stipple.geom"))));
+            break;
         default:
             throw(std::runtime_error("Unhandled geometry shader type.\n"));
     }
@@ -70,10 +74,6 @@ RenderableMaterial::RenderableMaterial(Qt3DCore::QNode *parent, VertexShaderType
         case (FragmentShaderType::Monochrome):
             shader3->setFragmentShaderCode(
                 Qt3DRender::QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/shaders/shaders/monochrome.frag"))));
-            break;
-        case (FragmentShaderType::LineStipple):
-            shader3->setFragmentShaderCode(
-                Qt3DRender::QShaderProgram::loadSource(QUrl(QStringLiteral("qrc:/shaders/shaders/line_stipple.frag"))));
             break;
         case (FragmentShaderType::Phong):
             shader3->setFragmentShaderCode(

--- a/src/material.h
+++ b/src/material.h
@@ -20,7 +20,7 @@ class RenderableMaterial : public Qt3DRender::QMaterial
     {
         None,
         LineTesselator,
-        LineStipple,
+        LineStipple
     };
     // Fragment Shader Types
     enum class FragmentShaderType

--- a/src/material.h
+++ b/src/material.h
@@ -19,15 +19,15 @@ class RenderableMaterial : public Qt3DRender::QMaterial
     enum class GeometryShaderType
     {
         None,
-        LineTesselator
+        LineTesselator,
+        LineStipple,
     };
     // Fragment Shader Types
     enum class FragmentShaderType
     {
         Monochrome,
         Phong,
-        PerVertexPhong,
-        LineStipple
+        PerVertexPhong
     };
     explicit RenderableMaterial(Qt3DCore::QNode *parent, VertexShaderType vertexShader, GeometryShaderType geometryShader,
                                 FragmentShaderType fragmentShader);

--- a/src/material.h
+++ b/src/material.h
@@ -26,7 +26,8 @@ class RenderableMaterial : public Qt3DRender::QMaterial
     {
         Monochrome,
         Phong,
-        PerVertexPhong
+        PerVertexPhong,
+        LineStipple
     };
     explicit RenderableMaterial(Qt3DCore::QNode *parent, VertexShaderType vertexShader, GeometryShaderType geometryShader,
                                 FragmentShaderType fragmentShader);

--- a/src/shaders.qrc
+++ b/src/shaders.qrc
@@ -5,7 +5,7 @@
     <file>shaders/phong.frag</file>
     <file>shaders/phongpervertex.frag</file>
     <file>shaders/monochrome.frag</file>
-    <file>shaders/line_stipple.geom</file>
     <file>shaders/line_tesselator.geom</file>
+    <file>shaders/line_stipple.geom</file>
   </qresource>
 </RCC>

--- a/src/shaders.qrc
+++ b/src/shaders.qrc
@@ -5,6 +5,7 @@
     <file>shaders/phong.frag</file>
     <file>shaders/phongpervertex.frag</file>
     <file>shaders/monochrome.frag</file>
+    <file>shaders/line_stipple.frag</file>
     <file>shaders/line_tesselator.geom</file>
   </qresource>
 </RCC>

--- a/src/shaders.qrc
+++ b/src/shaders.qrc
@@ -5,7 +5,7 @@
     <file>shaders/phong.frag</file>
     <file>shaders/phongpervertex.frag</file>
     <file>shaders/monochrome.frag</file>
-    <file>shaders/line_stipple.frag</file>
+    <file>shaders/line_stipple.geom</file>
     <file>shaders/line_tesselator.geom</file>
   </qresource>
 </RCC>

--- a/src/shaders/line_stipple.frag
+++ b/src/shaders/line_stipple.frag
@@ -11,7 +11,7 @@ uniform float line_stipple_pattern;
 void main() {
     float step = 1.0 / line_stipple_factor;
     float pattern = mod(position.x * step, line_stipple_pattern);
-    if (pattern > 0.5) {
+    if (pattern > 0.5 || pattern > 0.5) {
         discard;
     }
     gl_Position = vec4(position, 1.0);

--- a/src/shaders/line_stipple.frag
+++ b/src/shaders/line_stipple.frag
@@ -1,0 +1,35 @@
+#version 330 core
+
+layout (location = 0) in vec3 position;
+out vec4 color;
+
+uniform float line_width;
+uniform float line_stipple_factor;
+uniform float line_stipple_pattern;
+
+
+void main() {
+    float step = 1.0 / line_stipple_factor;
+    float pattern = mod(position.x * step, line_stipple_pattern);
+    if (pattern > 0.5) {
+        discard;
+    }
+    gl_Position = vec4(position, 1.0);
+    color = vec4(1.0, 0.0, 0.0, 1.0);
+}
+
+// Compile the shader
+GLuint shader = glCreateShader(GL_VERTEX_SHADER);
+glShaderSource(shader,1, &shader_source, NULL);
+glCompileShader(shader);
+
+// Bind the shader to the current OpenGl context
+glUseProgram(shader);
+
+// Set the uniforms
+glUniform1f(glGetUniformLocation(shader, "line_width"), 1.0f);
+glUniform1i(glGetUniformLocation(shader, "line_stipple_factor"), 1);
+glUniform1ui(glGetUniformLocation(shader, "line_stipple_pattern"), 0xFFFF);
+
+// Draw the line
+glDrawArrays(GL_LINE_STRIP, 0, 4);

--- a/src/shaders/line_stipple.geom
+++ b/src/shaders/line_stipple.geom
@@ -3,19 +3,28 @@
 layout (location = 0) in vec3 position;
 out vec4 color;
 
+
 uniform float line_width;
 uniform float line_stipple_factor;
 uniform float line_stipple_pattern;
 
+// Set the uniforms
+glUniform1f(glGetUniformLocation(shader, "line_width"), 1.0f);
+glUniform1i(glGetUniformLocation(shader, "line_stipple_factor"), 1);
+glUniform1ui(glGetUniformLocation(shader, "line_stipple_pattern"), 0xFFFF);
+
 
 void main() {
     float step = 1.0 / line_stipple_factor;
-    float pattern = mod(position.x * step, line_stipple_pattern);
+    float pattern = mod(dot(position.xy, vec2(1.0, line_width)), line_stipple_pattern);
     if (pattern > 0.5 || pattern > 0.5) {
-        discard;
+        color = vec4(0.0, 0.0, 0.0, 0.0);
+    } else {
+        color = vec4(1.0, 0.0, 0.0, 1.0);
     }
     gl_Position = vec4(position, 1.0);
-    color = vec4(1.0, 0.0, 0.0, 1.0);
+    EmitVertex();
+    EndPrimitive();
 }
 
 // Compile the shader
@@ -25,11 +34,6 @@ glCompileShader(shader);
 
 // Bind the shader to the current OpenGl context
 glUseProgram(shader);
-
-// Set the uniforms
-glUniform1f(glGetUniformLocation(shader, "line_width"), 1.0f);
-glUniform1i(glGetUniformLocation(shader, "line_stipple_factor"), 1);
-glUniform1ui(glGetUniformLocation(shader, "line_stipple_pattern"), 0xFFFF);
 
 // Draw the line
 glDrawArrays(GL_LINE_STRIP, 0, 4);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -195,7 +195,7 @@ Data1DEntity *MildredWidget::addData1D(std::string_view tag)
 
     // Add a material
     auto *material = createMaterial(entity, RenderableMaterial::VertexShaderType::ClippedToDataVolume,
-                                    RenderableMaterial::GeometryShaderType::LineTesselator,
+                                    RenderableMaterial::GeometryShaderType::LineStipple,
                                     RenderableMaterial::FragmentShaderType::PerVertexPhong);
     entity->setDataMaterial(material);
     entity->setErrorMaterial(material);


### PR DESCRIPTION
This Line Stipple Shader takes three uniforms:

* `line_width`: The width of the line in pixels.
* `line_stipple_factor`: The number of pixels between each stipple.
* `line_stipple_pattern`: A bit pattern that determines which pixels are stippled.

The shader uses the `mod()` function to determine if a pixel should be stippled. If the pixel's x-coordinate is divisible by the `line_stipple_factor`, then it is stippled. 

The shader also uses the `discard` keyword to discard any pixels that are stippled.

The  `line_width`, `line_stipple_factor`, and `line_stipple_pattern` uniforms have been set to enable the stippled line to be drawn on the output Example Binary.